### PR TITLE
Bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
-# ╰┈way.ts┈➤
+<h1 align="center">╰┈way.ts┈➤</h1>
+
+<div align="center">
+  <img src="https://img.shields.io/badge/Tested%20on%20Deno-2.0.0rc.10-blue"></img>
+</div>
+<br />
+
 A simple library I've made to work easily with paths in Deno 🦕 in a more standardized 🌎 and predictable way.
 
----
+<hr /><br />
 
 ## Why?
 
@@ -120,7 +126,7 @@ Checks whether the `entrypath` is located within the `sandbox` path. This check 
 function isSandboxed(sandbox: string | URL, entrypath: string | URL): boolean
 ```
 
----
+<br /><hr />
 
 ## LICENSE 🔒
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import * as way from 'https://raw.githubusercontent.com/jabonchan/way.ts/refs/he
 #### `way.normalize`
 > Unless otherwise stated, all paths returned by the functions in this module are passed to `way.normalize` first before being returned.
 
-Normalizes a path-like `string` or `URL`. Normalizes relative directives, removes surrounding slashes, parses `file:` URLs, uses upper case for drive letters, removes forbidden characters in Windows *(whether you're using UNIX-based systems or Windows)*. UNIX separators *(`/`)* are always used.
+Normalizes a path-like `string` or `URL`. Normalizes relative directives, removes surrounding slashes, parses `file:` URLs, uses upper case for drive letters, removes forbidden characters in Windows *(whether you're using UNIX-based systems or Windows)*. UNIX separators *(`/`)* are always used. Empty paths return `./`.
 ```ts
 function normalize(entrypath: string | URL): string
 ```

--- a/lib/methods/entry-path-checks.ts
+++ b/lib/methods/entry-path-checks.ts
@@ -19,10 +19,17 @@ export function isRelative(entrypath: string | URL) {
 }
 
 export function isSandboxed(sandbox: string | URL, entrypath: string | URL) {
-    if (isRelative(sandbox) || isRelative(entrypath) || separate(entrypath).length < 2) {
+    if (isRelative(sandbox) || isRelative(entrypath)) {
         return false;
     }
 
+    const entriesEntrypath = separate(entrypath);
+    const entriesSandbox = separate(sandbox);
+
+    if (entriesEntrypath.length <= entriesSandbox.length) {
+        return false;
+    }
+    
     const entryDirpath = `${dirpath(entrypath).toLowerCase()}/`;
     sandbox = `${normalize(sandbox).toLowerCase()}/`;
 

--- a/lib/methods/normalize.ts
+++ b/lib/methods/normalize.ts
@@ -4,9 +4,15 @@ import * as strings from '../strings.ts'
 import * as regexs from '../regexs.ts'
 
 export function normalize(entrypath: string | URL) {
+    entrypath = parseURL(entrypath);
+
+    if (regexs.ONLY_SEPARATORS.test(entrypath)) {
+        return '/';
+    }
+
     entrypath = strings.removeTrailing(
-                    parseURL(entrypath)
-                        .replace(regexs.FILE_PROTOCOL, strings.EMPTY)
+                    entrypath
+                        .replace(regexs.FILE_PROTOCOL, strings.UNIX_SEP)
                         .replace(regexs.PATH_SEP, strings.UNIX_SEP)
                         .replace(regexs.WINDOWS_ROOT, '$1:/'),
                         

--- a/lib/regexs.ts
+++ b/lib/regexs.ts
@@ -1,3 +1,5 @@
+export const ONLY_SEPARATORS = /^(\\|\/)+$/;
+
 export const FILE_PROTOCOL = /^file:(\\|\/)*/i;
 
 export const WINDOWS_ROOT = /^(?:\\|\/)*([a-zA-Z]):(?:\\|\/)*/;


### PR DESCRIPTION
This should fix some issues with normalize (specially with paths that were only a UNIX root). That was caused by the removeTrailing function.

This improves the isSandboxed function, now it uses dirpath and fixes the check, so now it *should* be safe and reliable to use. Tests will be added later tho to confirm it.

Reflected behavior for empty strings on README.md to make it clear how it works and also added badge that shows in what Deno version this library has been tested.